### PR TITLE
feat : 마이페이지에서 참여중,호스트인 파티 구분해서 조회

### DIFF
--- a/src/main/java/ita/tinybite/domain/party/repository/PartyParticipantRepository.java
+++ b/src/main/java/ita/tinybite/domain/party/repository/PartyParticipantRepository.java
@@ -68,4 +68,16 @@ public interface PartyParticipantRepository extends JpaRepository<PartyParticipa
             @Param("userId") Long userId,
             @Param("activeStatuses") List<PartyStatus> activeStatuses
     );
-}
+
+    @Query("SELECT pp FROM PartyParticipant pp " +
+            "JOIN FETCH pp.party p " +
+            "JOIN FETCH p.host " +
+            "WHERE pp.user.userId = :userId " +
+            "AND p.host.userId != :userId " +
+            "AND p.status = :partyStatus " +
+            "AND pp.status = :participantStatus")
+    List<PartyParticipant> findActivePartiesByUserIdExcludingHost(
+            @Param("userId") Long userId,
+            @Param("partyStatus") PartyStatus partyStatus,
+            @Param("participantStatus") ParticipantStatus participantStatus
+    );}

--- a/src/main/java/ita/tinybite/domain/party/repository/PartyRepository.java
+++ b/src/main/java/ita/tinybite/domain/party/repository/PartyRepository.java
@@ -7,6 +7,7 @@ import ita.tinybite.domain.party.enums.PartyCategory;
 import java.util.List;
 import java.util.Optional;
 
+import ita.tinybite.domain.party.enums.PartyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -20,5 +21,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     List<Party> findByPickupLocation_Place(String place);
 
     List<Party> findByPickupLocation_PlaceAndCategory(String place, PartyCategory category);
+
+    List<Party> findByHostUserIdAndStatus(Long userId, PartyStatus partyStatus);
 }
 

--- a/src/main/java/ita/tinybite/domain/user/controller/UserController.java
+++ b/src/main/java/ita/tinybite/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import ita.tinybite.global.response.APIResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -111,18 +112,64 @@ public class UserController {
         return success(response);
     }
 
-    @Operation(summary = "활성 파티 목록 조회", description = "사용자가 참여 중인 활성 파티 목록을 조회합니다.")
+    @Operation(
+            summary = "호스팅 중인 파티 목록 조회",
+            description = "현재 사용자가 호스트로 있는 활성 파티 목록을 조회합니다."
+    )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = PartyCardResponse.class)))),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = PartyCardResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
     })
-    @GetMapping("/parties/active")
-    public ResponseEntity<List<PartyCardResponse>> getActiveParties(
+    @GetMapping("/parties/hosting")
+    public ResponseEntity<List<PartyCardResponse>> getHostingParties(
             @AuthenticationPrincipal Long userId) {
-        List<PartyCardResponse> response = userService.getActiveParties(userId);
+        List<PartyCardResponse> response = userService.getHostingParties(userId);
         return ResponseEntity.ok(response);
     }
+
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = PartyCardResponse.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/parties/participating")
+    public ResponseEntity<List<PartyCardResponse>> getParticipatingParties(
+            @AuthenticationPrincipal Long userId) {
+        List<PartyCardResponse> response = userService.getParticipatingParties(userId);
+        return ResponseEntity.ok(response);
+    }
+
+//    @Operation(summary = "활성 파티 목록 조회", description = "사용자가 참여 중인 활성 파티 목록을 조회합니다.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "조회 성공",
+//                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = PartyCardResponse.class)))),
+//            @ApiResponse(responseCode = "401", description = "인증 실패")
+//    })
+//    @GetMapping("/parties/active")
+//    public ResponseEntity<List<PartyCardResponse>> getActiveParties(
+//            @AuthenticationPrincipal Long userId) {
+//        List<PartyCardResponse> response = userService.getActiveParties(userId);
+//        return ResponseEntity.ok(response);
+//    }
 
     @Operation(summary = "닉네임 중복 확인", description = "닉네임 사용 가능 여부를 확인합니다.")
     @ApiResponses({


### PR DESCRIPTION
## 📝 상세 내용
- 마이페이지에서 참여중,호스트인 파티 구분해서 조회
-  기존 마이페이지 파티 전체 조회 방식 삭제 
---

## 🔗 관련 이슈
- Closes #70 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 참여 중인 파티 목록을 조회할 수 있는 새로운 엔드포인트 추가됨
  * 호스트가 진행 중인 파티 목록 조회 기능 개선

* **Changes**
  * 기존 엔드포인트 경로 변경: `/parties/active` → `/parties/hosting`

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->