### PR TITLE
Fix : 호스트만 있을때는 파티 수정할 수 있도록 변경

### DIFF
--- a/src/main/java/ita/tinybite/domain/party/repository/PartyParticipantRepository.java
+++ b/src/main/java/ita/tinybite/domain/party/repository/PartyParticipantRepository.java
@@ -80,4 +80,7 @@ public interface PartyParticipantRepository extends JpaRepository<PartyParticipa
             @Param("userId") Long userId,
             @Param("partyStatus") PartyStatus partyStatus,
             @Param("participantStatus") ParticipantStatus participantStatus
-    );}
+    );
+
+    int countByPartyIdAndStatusAndUserIdNot(Long partyId, ParticipantStatus participantStatus, Long userId);
+}


### PR DESCRIPTION
## 📝 상세 내용
- 호스트만 있을때는 파티 전체 정보 수정할 수 있도록 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 파티 조회 쿼리의 파라미터 어노테이션 이름 수정
  * 파티 정보 업데이트 규칙 개선: 다른 승인된 참여자가 있을 경우 설명 및 이미지만 수정 가능하도록 변경

* **New Features**
  * 특정 사용자를 제외한 파티 참여자 수 조회 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->