### PR TITLE
fix : 파티 삭제시 호스트는 현재인원에서 제외하도록 수정

### DIFF
--- a/src/main/java/ita/tinybite/domain/party/service/PartyService.java
+++ b/src/main/java/ita/tinybite/domain/party/service/PartyService.java
@@ -404,10 +404,15 @@ public class PartyService {
             throw new IllegalStateException("파티장만 삭제할 수 있습니다");
         }
 
-        // 승인된 파티원 확인
-        boolean hasApprovedParticipants = party.getCurrentParticipants() > 1;
+        // 호스트 제외한 승인된 파티원 수 확인
+        int approvedParticipantsExcludingHost = participantRepository
+                .countByPartyIdAndStatusAndUserIdNot(
+                        partyId,
+                        ParticipantStatus.APPROVED,
+                        userId
+                );
 
-        if (hasApprovedParticipants) {
+        if (approvedParticipantsExcludingHost > 0) {
             throw new IllegalStateException("승인된 파티원이 있어 삭제할 수 없습니다");
         }
 


### PR DESCRIPTION
## 📝 상세 내용
- 파티 삭제시 호스트는 현재인원에서 제외하도록 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 파티 삭제 시 참여자 조건 검사 로직을 개선했습니다. 호스트를 제외한 승인된 참여자 수를 더 정확하게 계산하여 삭제 권한을 판단하도록 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->