### PR TITLE
hotfix : 파티 삭제 되지 않는 문제 수정

### DIFF
--- a/src/main/java/ita/tinybite/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/ita/tinybite/domain/chat/repository/ChatRoomRepository.java
@@ -10,7 +10,8 @@ import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
     Optional<ChatRoom> findByPartyAndType(Party party, ChatRoomType type);
+
+    void deleteByPartyIdAndType(Long partyId, ChatRoomType type);
 
 }

--- a/src/main/java/ita/tinybite/domain/party/repository/PartyRepository.java
+++ b/src/main/java/ita/tinybite/domain/party/repository/PartyRepository.java
@@ -1,6 +1,7 @@
 package ita.tinybite.domain.party.repository;
 
 import io.lettuce.core.dynamic.annotation.Param;
+import ita.tinybite.domain.chat.enums.ChatRoomType;
 import ita.tinybite.domain.party.entity.Party;
 import ita.tinybite.domain.party.enums.PartyCategory;
 import java.util.List;

--- a/src/main/java/ita/tinybite/domain/party/service/PartyService.java
+++ b/src/main/java/ita/tinybite/domain/party/service/PartyService.java
@@ -386,6 +386,8 @@ public class PartyService {
             throw new IllegalStateException("승인된 파티원이 있어 삭제할 수 없습니다");
         }
 
+         chatRoomRepository.deleteByPartyIdAndType(partyId, ChatRoomType.GROUP);
+        
         // 삭제 실행
         partyRepository.delete(party);
     }


### PR DESCRIPTION
## 📝 상세 내용
파티 삭제가  되지 않는 문제 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 파티 또는 그룹을 삭제할 때 관련 그룹 채팅방이 자동으로 함께 삭제됩니다. 이를 통해 불필요한 채팅 데이터 누적을 방지하고 데이터 일관성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->