### PR TITLE
Fix : 마이페이지에서 참여중, 호스트 파티 조회시 최신순으로 조회되도록 수정

### DIFF
--- a/src/main/java/ita/tinybite/domain/user/controller/UserController.java
+++ b/src/main/java/ita/tinybite/domain/user/controller/UserController.java
@@ -158,19 +158,6 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-//    @Operation(summary = "활성 파티 목록 조회", description = "사용자가 참여 중인 활성 파티 목록을 조회합니다.")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "조회 성공",
-//                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = PartyCardResponse.class)))),
-//            @ApiResponse(responseCode = "401", description = "인증 실패")
-//    })
-//    @GetMapping("/parties/active")
-//    public ResponseEntity<List<PartyCardResponse>> getActiveParties(
-//            @AuthenticationPrincipal Long userId) {
-//        List<PartyCardResponse> response = userService.getActiveParties(userId);
-//        return ResponseEntity.ok(response);
-//    }
-
     @Operation(summary = "닉네임 중복 확인", description = "닉네임 사용 가능 여부를 확인합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용 가능한 닉네임"),

--- a/src/main/java/ita/tinybite/domain/user/service/UserService.java
+++ b/src/main/java/ita/tinybite/domain/user/service/UserService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -181,6 +182,7 @@ public class UserService {
         );
 
         return parties.stream()
+                .sorted(Comparator.comparing(Party::getCreatedAt).reversed())
                 .map(party -> {
                     int currentParticipants = participantRepository
                             .countByPartyIdAndStatus(party.getId(), ParticipantStatus.APPROVED);
@@ -198,6 +200,8 @@ public class UserService {
                 );
 
         return participants.stream()
+                .sorted(Comparator.comparing(pp -> pp.getParty().getCreatedAt(),
+                        Comparator.reverseOrder()))
                 .map(pp -> {
                     Party party = pp.getParty();
                     int currentParticipants = participantRepository


### PR DESCRIPTION
## 📝 상세 내용
- 마이페이지에서 참여중, 호스트 파티 조회시 최신순으로 조회되도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 호스팅 및 참여 중인 파티 목록이 생성 날짜를 기준으로 최신순으로 정렬되어 표시됩니다.

* **API 변경**
  * `/parties/active` 공개 엔드포인트가 제거되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->